### PR TITLE
fix macos getlocale is None error

### DIFF
--- a/DrissionPage/_functions/settings.py
+++ b/DrissionPage/_functions/settings.py
@@ -19,7 +19,7 @@ class Settings(object):
     cdp_timeout = 30
     browser_connect_timeout = 30
     auto_handle_alert = None
-    _lang = get_txt_class('zh_cn' if 'chinese' in getlocale()[0].lower() else 'en')
+    _lang = get_txt_class('zh_cn' if locale.getlocale()[0] and 'chinese' in getlocale()[0].lower() else 'en')
     suffixes_list = str(Path(__file__).parent.absolute() / 'suffixes.dat').replace('\\', '/')
 
     @classmethod


### PR DESCRIPTION
Fix: Handle None error in locale detection for language settings

- Added a check to ensure `locale.getlocale()[0]` is not None before calling `.lower()`.
- Prevents potential `AttributeError` when locale information is missing or unset.
- Defaulted to 'en' if the locale language is unavailable.


> 修正在macos上，getlocal的输出可能是(None, 'UTF-8')，此时会报AttributeError: 'NoneType' object has no attribute 'lower'错误（Macbook M1 Pro)